### PR TITLE
Include consul-bridge on stretch images

### DIFF
--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -74,4 +74,7 @@ ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 # (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
 
+RUN wget -q http://ht-infra-tools.s3.amazonaws.com/consul-bridge_0.0.6_linux64 -O /usr/bin/consul-bridge
+RUN chmod +x /usr/bin/consul-bridge
+
 CMD [ "irb" ]

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -74,4 +74,7 @@ ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 # (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
 
+RUN wget -q http://ht-infra-tools.s3.amazonaws.com/consul-bridge_0.0.6_linux64 -O /usr/bin/consul-bridge
+RUN chmod +x /usr/bin/consul-bridge
+
 CMD [ "irb" ]

--- a/2.6/stretch/Dockerfile
+++ b/2.6/stretch/Dockerfile
@@ -70,4 +70,7 @@ ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 # (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
 
+RUN wget -q http://ht-infra-tools.s3.amazonaws.com/consul-bridge_0.0.6_linux64 -O /usr/bin/consul-bridge
+RUN chmod +x /usr/bin/consul-bridge
+
 CMD [ "irb" ]


### PR DESCRIPTION
Connectivity's Dockerfile executes `consul-bridge` and the ruby base image doesn't include it. 

Instead of downloading `consul-bridge` from `ht-infra-tools` each time the app is built it makes sense to include it in the ruby base image. 